### PR TITLE
Changed determination of whether a triangle is in front of another

### DIFF
--- a/toolbox/calc/calc_coeff.m
+++ b/toolbox/calc/calc_coeff.m
@@ -156,7 +156,7 @@ for ii = 1:indexAoA
         
         % Shadow analysis
         if flag_shad
-            [shadPan] = shadowAnaly(x, y, z, barC, delta, L_gw);
+            [shadPan] = shadowAnaly(x, y, z, barC, delta, L_gw, surfN);
             
             cp(shadPan) = 0;
             ctau(shadPan) = 0;

--- a/toolbox/calc/shadowAnaly.m
+++ b/toolbox/calc/shadowAnaly.m
@@ -1,4 +1,4 @@
-function [ shadPan ] = shadowAnaly( x, y, z, barC, delta, L_gw)
+function [ shadPan ] = shadowAnaly( x, y, z, barC, delta, L_gw, surfN)
 %SHADOWANALY Checks for mesh elements shadowed from a direction by others
 %
 % Inputs:
@@ -103,7 +103,8 @@ for i=1:length(indFPot)
 
                 else
                  
-                 if any((barCw(1,indB(indBPot((yC_chang(zC_chang(Ftest))))))-barCw(1,indF(indFPot(i))))> tolB)
+                 if any(dot(L_gw' * surfN(:,indB(indBPot(yC_chang(zC_chang(Ftest))))), ...
+                     barCw(:,indF(indFPot(i))) - pAw(:, indB(indBPot(yC_chang(zC_chang(Ftest)))))) > tolB)
                     shadPan(indF(indFPot(i))) = 1;
                  end
                  


### PR DESCRIPTION
Before this commit, the shadowing function checked whether a triangle A is in front of another triangle B (and thus able to shadow triangle B) by comparing the x coordinate of the triangles' barycenters in wind frame. However, triangle A can be behind triangle B even if triangle A's barycenter is in front of triangle B's barycenter.

This commit changes the shadowing function in the following way:

1. It calculates a vector from some vertex of the potentially shadowing triangle A to the barycenter of the potentially shadowed triangle B.
2. It calculates the dot product of this vector with the surface normal of A.
3. If the dot product is positive, then the barycenter of B lies "in the direction" of the surface normal of A. Since only backwards facing panels are considered for A, this also means that the barycenter of B lies **behind** A.

The following obj file is an example of where the previous shadowing function would label one front triangle shadowed by a back triangle of the simple cuboid (for aoa = aos = 0). The new shadowing function seems to get it right.

```
# File units = meters
mtllib testplatte.mtl
g Part 1
v -0.00707107 0.00707107 0 
v 0 0 0 
v 0.122788 0.122788 0.984808 
v 0.115717 0.129859 0.984808 
v 1.03748 1.05162 -0.260472 
v 1.04455 1.04455 -0.260472 
v 1.16733 1.16733 0.724335 
v 1.16026 1.17441 0.724335 
vn -0.696364 -0.696364 0.173648 
vn -0.122788 -0.122788 -0.984808 
vn 0.696364 0.696364 -0.173648 
vn 0.122788 0.122788 0.984808 
vn -0.707107 0.707107 0 
vn 0.707107 -0.707107 0 
usemtl 0.615686_0.811765_0.929412_0.000000_0.000000
o mesh0
f 2//1 3//1 4//1 
f 4//1 1//1 2//1 
o mesh1
f 1//2 5//2 6//2 
f 6//2 2//2 1//2 
o mesh2
f 7//3 6//3 5//3 
f 5//3 8//3 7//3 
o mesh3
f 4//4 3//4 7//4 
f 7//4 8//4 4//4 
o mesh4
f 8//5 5//5 1//5 
f 1//5 4//5 8//5 
o mesh5
f 3//6 2//6 6//6 
f 6//6 7//6 3//6 
```